### PR TITLE
Remove github actions from being templated

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,5 +7,8 @@
   "project_short_description": "package description.",
   "pypi_username": "{{ cookiecutter.github_username }}",
   "version_control": ["setuptools-scm", "bump2version", "None"],
-  "license": ["BSD license", "MIT license", "No license"]
+  "license": ["BSD license", "MIT license", "No license"],
+  "_copy_without_render": [
+		".github/workflows/*"
+	]
 }


### PR DESCRIPTION
Otherwise cookiecutter tries to fill in the templating in that file.

Also this is handy stuff!