### PR TITLE
fix path to version

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -17,7 +17,7 @@ dynamic = ["version"]
 dependencies = []
 
 [tool.hatch.version]
-path = "{{ cookiecutter.project_slug }}/__init__.py"
+path = "src/{{ cookiecutter.project_slug }}/__init__.py"
 
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies


### PR DESCRIPTION
In the simple version, the path to the version is incorrect and leads to an error when pip installing. The ```src``` subfolder is missing.